### PR TITLE
Added typescript definitions

### DIFF
--- a/dist/notiwind.d.ts
+++ b/dist/notiwind.d.ts
@@ -1,0 +1,12 @@
+declare module 'notiwind' {
+    import {Plugin} from 'vue'
+    const Notifications: Plugin
+    export default Notifications
+
+    interface Notification {
+        group?: string,
+        [key: string]: any,
+    }
+
+    export function notify(notification: Notification, time: number): void
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.2.5",
   "main": "dist/index.common.js",
   "module": "dist/index.esm.js",
+  "types": "dist/notiwind.d.ts",
   "license": "MIT",
   "author": {
     "name": "Emmanuel Deossa",


### PR DESCRIPTION
Compared to #20, these definitions does not declare fixed fields.
Notiwind itself only expect a field `group` and this is optional.
Can be found here: https://github.com/emmanuelsw/notiwind/blob/main/src/notify.js#L11

All other fields are optional and UI implementation specific.
That's the reason why `Notification` is a map type, in this definition.

At least I added the `types` entry in the `package.json`, otherwise typescript or build tools may not resolve the `.d.ts` automatically.