### PR TITLE
Feature/programmatic closure

### DIFF
--- a/dist/index.common.js
+++ b/dist/index.common.js
@@ -54,6 +54,7 @@ var script$1 = {
   data() {
     return {
       notifications: [],
+      timeouts: {},
     }
   },
   computed: {
@@ -74,6 +75,7 @@ var script$1 = {
   },
   mounted() {
     events.on('notify', this.add);
+    events.on('close', this.remove);
   },
   methods: {
     add({ notification, timeout}) {
@@ -81,7 +83,7 @@ var script$1 = {
 
       this.notifications.push(notification);
 
-      setTimeout(() => {
+      this.timeouts[notification.id] = setTimeout(() => {
         this.remove(notification.id);
       }, timeout || DEFAULT_TIMEOUT);
     },
@@ -91,6 +93,8 @@ var script$1 = {
     },
     remove(id) {
       this.notifications.splice(this.notifications.findIndex(n => n.id === id), 1);
+
+      clearTimeout(this.timeouts[id]);
     }
   },
   render() {
@@ -160,6 +164,8 @@ const notify = (notification, timeout) => {
   notification.id = generateId();
   notification.group = notification.group || '';
   events.emit('notify', { notification, timeout });
+
+  return () => events.emit('close', notification.id)
 };
 
 /* eslint-disable vue/component-definition-name-casing */

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -50,6 +50,7 @@ var script$1 = {
   data() {
     return {
       notifications: [],
+      timeouts: {},
     }
   },
   computed: {
@@ -70,6 +71,7 @@ var script$1 = {
   },
   mounted() {
     events.on('notify', this.add);
+    events.on('close', this.remove);
   },
   methods: {
     add({ notification, timeout}) {
@@ -77,7 +79,7 @@ var script$1 = {
 
       this.notifications.push(notification);
 
-      setTimeout(() => {
+      this.timeouts[notification.id] = setTimeout(() => {
         this.remove(notification.id);
       }, timeout || DEFAULT_TIMEOUT);
     },
@@ -87,6 +89,8 @@ var script$1 = {
     },
     remove(id) {
       this.notifications.splice(this.notifications.findIndex(n => n.id === id), 1);
+
+      clearTimeout(this.timeouts[id]);
     }
   },
   render() {
@@ -156,6 +160,8 @@ const notify = (notification, timeout) => {
   notification.id = generateId();
   notification.group = notification.group || '';
   events.emit('notify', { notification, timeout });
+
+  return () => events.emit('close', notification.id)
 };
 
 /* eslint-disable vue/component-definition-name-casing */

--- a/src/Notification.vue
+++ b/src/Notification.vue
@@ -48,6 +48,7 @@ export default {
   data() {
     return {
       notifications: [],
+      timeouts: {},
     }
   },
   computed: {
@@ -76,6 +77,7 @@ export default {
       this.notifications.push(notification)
 
       setTimeout(() => {
+      this.timeouts[notification.id] = setTimeout(() => {
         this.remove(notification.id)
       }, timeout || DEFAULT_TIMEOUT)
     },
@@ -85,6 +87,8 @@ export default {
     },
     remove(id) {
       this.notifications.splice(this.notifications.findIndex(n => n.id === id), 1)
+
+      clearTimeout(this.timeouts[id])
     }
   },
   render() {

--- a/src/Notification.vue
+++ b/src/Notification.vue
@@ -69,6 +69,7 @@ export default {
   },
   mounted() {
     events.on('notify', this.add)
+    events.on('close', this.remove)
   },
   methods: {
     add({ notification, timeout}) {
@@ -76,7 +77,6 @@ export default {
 
       this.notifications.push(notification)
 
-      setTimeout(() => {
       this.timeouts[notification.id] = setTimeout(() => {
         this.remove(notification.id)
       }, timeout || DEFAULT_TIMEOUT)

--- a/src/notify.js
+++ b/src/notify.js
@@ -10,4 +10,6 @@ export const notify = (notification, timeout) => {
   notification.id = generateId()
   notification.group = notification.group || ''
   events.emit('notify', { notification, timeout })
+
+  return () => events.emit('close', notification.id)
 }


### PR DESCRIPTION
Fixed rare bug where a timeout of a dismissed notification can close a new notification prematurely

Update notify() to return a function allowing the notification to be closed programmatically