### PR TITLE
Export components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import { install } from './plugin'
 export { notify } from './notify'
+export { default as NotificationGroup } from './NotificationGroup.vue'
+export { default as Notification } from './Notification.vue'
 
 export default {
   install,


### PR DESCRIPTION
By exporting the NotificationGroup and Notification components the package becomes more flexible (user no longer has to use it as a plugin).