### PR TITLE
Add ability to specify INFINITE_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ this.$notify({
 
 The first argument is an object containing the data for the `Notification` element, it's important to specify the group where the notificatoins are going to be displayed, the second argument is the timeout. The default timeout is 3 seconds.
 
+If you need to keep the notification on the screen forever use `-1` as a timeout:
+
+```javascript
+this.$notify({
+  group: "foo",
+  title: "Success",
+  text: "Your account was registered!"
+}, -1) // it's not going to disappear automatically
+```
+
+
 ### Example with differents groups
 
 You can use the `NotificationGroup` component to have different types of notifications. For example, notifications error messages in top center and generic app notifications in bottom-right corner.

--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -10,6 +10,12 @@
         Top notification
       </button>
       <button
+        class="px-4 py-2 font-bold text-white bg-green-500 rounded hover:bg-green-600 focus:outline-none focus:ring"
+        @click="onClickTopInfinite"
+      >
+        Top notification infinite
+      </button>
+      <button
         class="px-4 py-2 font-bold text-white bg-red-500 rounded hover:bg-red-600 focus:outline-none focus:ring"
         @click="onClickBot"
       >
@@ -158,6 +164,17 @@ function onClickTop() {
     4000
   );
 }
+
+function onClickTopInfinite() {
+  notify(
+    {
+      group: "top",
+      title: "Success",
+      text: "I'm not going to disappear until you close me 😎",
+    },
+    -1
+  );
+ }
 
 function onClickBot() {
   notify(

--- a/src/Notification.vue
+++ b/src/Notification.vue
@@ -68,13 +68,17 @@ const add = ({
   timeout?: number;
 }) => {
   const DEFAULT_TIMEOUT = 3000;
+  const INFINITE_TIMEOUT = -1;
 
   state.notifications.push(notification);
 
   state.timeouts[notification.id] = window.setTimeout(() => {
+    if (timeout === INFINITE_TIMEOUT) return;
+
     remove(notification.id);
-  }, timeout || DEFAULT_TIMEOUT);
-};
+
+    // use Math.max to make sure we don't pass INFINITE_TIMEOUT to setTimeout
+  }, Math.max(timeout || DEFAULT_TIMEOUT, 0)); };
 
 const close = (id: Notification["id"]) => {
   emit("close");


### PR DESCRIPTION
hey @emmanuelsw, 
Thanks for the library! 

We use it in our project and there are some cases when we want to keep this notification on the screen forever. To do so we specify weird timeouts like `99999999`. 
Looking through the repo I found this discussion https://github.com/emmanuelsw/notiwind/discussions/12 and I totally agree that `-1` makes a lot of sense to use as "infinite timeout" argument. 

In this PR I've added `INFINITE_TIMEOUT` const, updated readme and updated the example page. 

I'm not sure if I should commit dist files too, please let me know if I should. Also let me know if you have better idea on how to implement it. 

Thanks!