### PR TITLE
fix: resolved type checking issue in SlotProps interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notiwind",
   "description": "A headless Vue 3 notification library to use with Tailwind CSS.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "dist/index.common.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/defineNotificationComponent.ts
+++ b/src/defineNotificationComponent.ts
@@ -6,7 +6,7 @@ import {
   Notification,
 } from "./types";
 
-interface SlotProps<T extends NotificationSchema> {
+export interface SlotProps<T extends NotificationSchema> {
   notifications: Notification<T>[];
   close: (id: Notification["id"]) => void;
   hovering: (id: Notification["id"], value: boolean, timeout?: number) => void;


### PR DESCRIPTION
## Fix: Type Error in SlotProps Interface

### Issue description

-  I encountered a type-check error while integrating notification system into my project, which appears to have been caused by a missing export declaration in the `SlotProps` interface.

![error](https://github.com/emmanuelsw/notiwind/assets/113229528/e47a0814-5519-49bb-8696-ec8a4a79f3c8)

### Resolution
- To resolve this issue, I added an `export` keyword to the `SlotProps` interface declaration. This modifiaction ensures that the type is correctly recognized and utilized accross different modules.

![solved](https://github.com/emmanuelsw/notiwind/assets/113229528/82dcecdd-eaff-4a78-8dab-aca8b2502609)

PS: If I made any mistakes, I am open to collaboration 😄 
